### PR TITLE
Downgrade Spock to v1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,13 @@
 junitVersion = 5.9.2
-jenkinsPipelineUnitVersion = 1.19
-spockVersion = 2.4-M1-groovy-3.0
+jenkinsPipelineUnitVersion = 1.17
+spockVersion = 1.3-groovy-2.4
 
 # Set version as close as possible to the version of Jenkins in production environment
 # Last version of Jenkins which can run on top of Java 8: 2.346.1
 # Newer versions require at least Java 11
 jenkinsVersion = 2.361.4
 
-# Spock 2 requires Groovy 3
-groovyVersion = 3.0.20
+groovyVersion = 2.4.21
 
 # Maven GAV coordinates of Jenkins plugins required in tests' runtime.
 # They should match our jenkinsVersion, appropriate version matching of plugins to

--- a/test/org/example/FooSpec.groovy
+++ b/test/org/example/FooSpec.groovy
@@ -31,7 +31,6 @@ class FooSpec extends PipelineSpockTestBase {
             assertCallStackContains('git clone https://example.org/foo')
     }
 
-    @Ignore('Test with inline script which loads library hangs (https://github.com/jenkinsci/JenkinsPipelineUnit/issues/472)')
     def 'Foo performs clone if called from inline script and git is new'() {
         given:
             helper.addShMock('git --version', 'git version 2.40', 0)


### PR DESCRIPTION
Downgrade Spock to v1 to fix error that Jenkins Test Harness cannot create instance of Jenkins